### PR TITLE
Validate wildcard usage in the action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,10 +57,28 @@ jobs:
         run: |
           echo foo > /tmp/foo.out
           echo bar > /tmp/bar.out
+          echo baz > /tmp/baz.out
 
-      - uses: ./.
+      - name: Happy path
+        uses: ./.
         with:
           command: python -c "print('foo', file=open('/tmp/foo.out', mode='w')); print('bar', file=open('/tmp/bar.out', mode='w'))"
           files: |
             /tmp/foo.out
-            /tmp/bar.out
+            /tmp/ba*.out
+
+      - name: Mismatch in wildcard file
+        uses: ./.
+        continue-on-error: true
+        id: should-fail
+        with:
+          command: python -c "print('BAR', file=open('/tmp/baz.out', mode='w'))"
+          files: |
+            /tmp/foo.out
+            /tmp/ba*.out
+
+      - name: Check expected failure
+        if: ${{ steps.should-fail.outcome != 'failure' }}
+        run: |
+          echo "Unexpected outcome from mismatched files: ${{ steps.should-fail.outcome }} != failure"
+          exit 1

--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ steps:
   - uses: PeterJCLaw/validate-generated-files@v1
     with:
       command: pip-compile
-      files: requirements.txt
+      files: requirements*.txt
 ```


### PR DESCRIPTION
They're not expected to be supported in the underlying python script, just the action. If using the script directly it's the caller's responsibility to enumerate all the files explicitly.

It turns out that this already worked, so the changes here just validate the desired behaviour.